### PR TITLE
Update Main.cpp

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -272,6 +272,7 @@ void MainLoop(void* arg)
         if (ImGui::Combo("Scene", &sampleSceneIndex, scenes.data(), scenes.size()))
         {
             LoadScene(sceneFiles[sampleSceneIndex]);
+            SDL_RestoreWindow(loopdata.mWindow);
             SDL_SetWindowSize(loopdata.mWindow, renderOptions.resolution.x, renderOptions.resolution.y);
             InitRenderer();
         }


### PR DESCRIPTION
Hi, thanks for sharing this project. I have found a great learning resource in it. 

I have found a small bug in Ubuntu. This is a possible fix.

> When a new scene is selected, restore the window before setting it's size. I think this is because, in Ubuntu, if the window was maximized, the window is not resizeable. Restoring the window makes it exit the the "maximized" mode.