### PR TITLE
Added ACES tonemapping

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -312,6 +312,7 @@ void MainLoop(void* arg)
             optionsChanged |= ImGui::ColorEdit3("Background Color", (float*)bgCol, 0);
             ImGui::Checkbox("Enable Denoiser", &renderOptions.enableDenoiser);
             ImGui::SliderInt("Number of Frames to skip", &renderOptions.denoiserFrameCnt, 5, 50);
+            requiresReload |= ImGui::Checkbox("Use ACES tonemapping", &renderOptions.useAces);
             
             if (requiresReload)
             {

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -51,6 +51,7 @@ namespace GLSLPT
             bgColor = Vec3(0.3f, 0.3f, 0.3f);
             denoiserFrameCnt = 20;
             enableDenoiser = false;
+            useAces = true;
         }
         iVec2 resolution;
         int maxDepth;
@@ -60,6 +61,7 @@ namespace GLSLPT
         bool enableRR;
         bool enableDenoiser;
         bool useConstantBg;
+        bool useAces;
         int RRDepth;
         int denoiserFrameCnt;
         float hdrMultiplier;

--- a/src/core/TiledRenderer.cpp
+++ b/src/core/TiledRenderer.cpp
@@ -91,34 +91,49 @@ namespace GLSLPT
         ShaderInclude::ShaderSource tonemapShaderSrcObj         = ShaderInclude::load(shadersDirectory + "tonemap.glsl");
 
         // Add preprocessor defines for conditional compilation
-        std::string defines = "";
+        std::string pathtraceDefines = "";
         if (scene->renderOptions.useEnvMap && scene->hdrData != nullptr)
-            defines += "#define ENVMAP\n";
+            pathtraceDefines += "#define ENVMAP\n";
         if (!scene->lights.empty())
-            defines += "#define LIGHTS\n";
+            pathtraceDefines += "#define LIGHTS\n";
         if (scene->renderOptions.enableRR)
         {
-            defines += "#define RR\n";
-            defines += "#define RR_DEPTH " + std::to_string(scene->renderOptions.RRDepth) + "\n";
+            pathtraceDefines += "#define RR\n";
+            pathtraceDefines += "#define RR_DEPTH " + std::to_string(scene->renderOptions.RRDepth) + "\n";
         }
         if (scene->renderOptions.useConstantBg)
-            defines += "#define CONSTANT_BG\n";
+            pathtraceDefines += "#define CONSTANT_BG\n";
 
-        if (defines.size() > 0)
+        std::string tonemapDefines = "";
+
+        if (scene->renderOptions.useAces)
+            tonemapDefines += "#define USE_ACES\n";
+
+        if (pathtraceDefines.size() > 0)
         {
             size_t idx = pathTraceShaderSrcObj.src.find("#version");
             if (idx != -1)
                 idx = pathTraceShaderSrcObj.src.find("\n", idx);
             else
                 idx = 0;
-            pathTraceShaderSrcObj.src.insert(idx + 1, defines);
+            pathTraceShaderSrcObj.src.insert(idx + 1, pathtraceDefines);
 
             idx = pathTraceShaderLowResSrcObj.src.find("#version");
             if (idx != -1)
                 idx = pathTraceShaderLowResSrcObj.src.find("\n", idx);
             else
                 idx = 0;
-            pathTraceShaderLowResSrcObj.src.insert(idx + 1, defines);
+            pathTraceShaderLowResSrcObj.src.insert(idx + 1, pathtraceDefines);
+        }
+
+        if (tonemapDefines.size() > 0)
+        {
+            size_t idx = tonemapShaderSrcObj.src.find("#version");
+            if (idx != -1)
+                idx = tonemapShaderSrcObj.src.find("\n", idx);
+            else
+                idx = 0;
+            tonemapShaderSrcObj.src.insert(idx + 1, tonemapDefines);
         }
 
         pathTraceShader       = LoadShaders(vertexShaderSrcObj, pathTraceShaderSrcObj);

--- a/src/loaders/Loader.cpp
+++ b/src/loaders/Loader.cpp
@@ -234,6 +234,7 @@ namespace GLSLPT
                     sscanf(line, " tileHeight %i", &renderOptions.tileHeight);
                     sscanf(line, " enableRR %s", enableRR);
                     sscanf(line, " RRDepth %i", &renderOptions.RRDepth);
+                    sscanf(line, " useAces %s", &renderOptions.useAces);
                 }
 
                 if (strcmp(envMap, "None") != 0)

--- a/src/shaders/tonemap.glsl
+++ b/src/shaders/tonemap.glsl
@@ -30,7 +30,20 @@ in vec2 TexCoords;
 uniform sampler2D pathTraceTexture;
 uniform float invSampleCounter;
 
-vec4 ToneMap(in vec4 c, float limit)
+vec4 tonemapACES(in vec4 c, float limit)
+{
+    float a = 2.51f;
+    float b = 0.03f;
+    float y = 2.43f;
+    float d = 0.59f;
+    float e = 0.14f;
+
+    float luminance = 0.3*c.x + 0.6*c.y + 0.1*c.z;
+
+    return clamp((c * (a * c + b)) / (c * (y * c + d) + e), 0.0, 1.0);
+}
+
+vec4 tonemap(in vec4 c, float limit)
 {
     float luminance = 0.3*c.x + 0.6*c.y + 0.1*c.z;
 
@@ -40,5 +53,12 @@ vec4 ToneMap(in vec4 c, float limit)
 void main()
 {
     color = texture(pathTraceTexture, TexCoords) * invSampleCounter;
-    color = pow(ToneMap(color, 1.5), vec4(1.0 / 2.2));
+    
+    #ifdef USE_ACES
+    color = pow(tonemapACES(color, 1.5), vec4(1.0 / 2.2));
+    #endif
+    
+    #ifndef USE_ACES
+    color = pow(tonemap(color, 1.5), vec4(1.0 / 2.2));
+    #endif
 }


### PR DESCRIPTION
Added a quick, simple implementation of ACES tonemapping from back my fork of this renderer as I thought it could be useful as a more general feature here as well. The fork adds support for (simulated) ACES tonemapping, resulting in higher contrast and perceived dynamic range and more vibrant colors, and a switch to enable and disable this tonemapping at runtime.